### PR TITLE
Quoted Printable: Prevent that the next line's first character is a dot

### DIFF
--- a/src/Mime.php
+++ b/src/Mime.php
@@ -131,6 +131,12 @@ class Mime
                 --$ptr;
             }
 
+            // Try to prevent that the first character of a line is a dot
+            // Outlook Bug: http://engineering.como.com/ghost-vs-outlook/
+            while ($ptr > 1 && $ptr < strlen($str) && $str[$ptr] === '.') {
+                --$ptr;
+            }
+
             // Add string and continue
             $out .= substr($str, 0, $ptr) . '=' . $lineEnd;
             $str = substr($str, $ptr);

--- a/test/MimeTest.php
+++ b/test/MimeTest.php
@@ -75,6 +75,16 @@ class MimeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(quoted_printable_decode($qp), $text);
     }
 
+    public function testQuotedPrintableNoDotAtBeginningOfLine()
+    {
+        $text = str_repeat('a', Mime\Mime::LINELENGTH) . '.bbb';
+        $qp = Mime\Mime::encodeQuotedPrintable($text);
+
+        $expected = str_repeat('a', Mime\Mime::LINELENGTH - 1) . "=\na.bbb";
+
+        $this->assertEquals($expected, $qp);
+    }
+
     public function testBase64()
     {
         $content = str_repeat("\x88\xAA\xAF\xBF\x29\x88\xAA\xAF\xBF\x29\x88\xAA\xAF", 4);


### PR DESCRIPTION
At least when used in combination with Exchange, Microsoft Outlook strips dots that appear at the beginning of a new line. We try to workaround this bug by wrapping early and thus preventing lines from starting with a dot.

See http://engineering.como.com/ghost-vs-outlook/
