### PR TITLE
Fix issue with parsing MIME parts with no headers

### DIFF
--- a/src/Decode.php
+++ b/src/Decode.php
@@ -105,7 +105,8 @@ class Decode
             $message = $message->toString();
         }
         // check for valid header at first line
-        $firstline = strtok($message, "\n");
+        $firstlinePos = strpos($message, "\n");
+        $firstline = $firstlinePos === false ? $message : substr($message, 0, $firstlinePos);
         if (!preg_match('%^[^\s]+[^:]*:%', $firstline)) {
             $headers = [];
             // TODO: we're ignoring \r for now - is this function fast enough and is it safe to assume noone needs \r?

--- a/test/MessageTest.php
+++ b/test/MessageTest.php
@@ -112,6 +112,41 @@ EOD;
         $this->assertEquals('12', $part2->id);
     }
 
+    /**
+     * check if decoding a string into a \Zend\Mime\Message object works
+     *
+     */
+    public function testDecodeMimeMessageNoHeader()
+    {
+        $text = <<<EOD
+This is a MIME-encapsulated message
+
+--=_af4357ef34b786aae1491b0a2d14399f
+
+The original message was received at Fri, 16 Aug 2013 00:00:48 -0700
+from localhost.localdomain [127.0.0.1]
+End content
+
+--=_af4357ef34b786aae1491b0a2d14399f
+Content-Type: image/gif
+
+This is a test
+--=_af4357ef34b786aae1491b0a2d14399f--
+EOD;
+        $res = Mime\Message::createFromMessage($text, '=_af4357ef34b786aae1491b0a2d14399f');
+
+        $parts = $res->getParts();
+        $this->assertEquals(2, count($parts));
+
+        $part1 = $parts[0];
+        $part1Content = $part1->getRawContent();
+        $this->assertContains('The original message', $part1Content);
+        $this->assertContains('End content', $part1Content);
+
+        $part2 = $parts[1];
+        $this->assertEquals('image/gif', $part2->type);
+    }
+
     public function testNonMultipartMessageShouldNotRemovePartFromMessage()
     {
         $message = new Mime\Message();  // No Parts


### PR DESCRIPTION
Parsing of MIME parts some times failed when there were no headers
present. This is due to the attempt to match the first line unexpectedly
matching the second (since strtok will skip a match at position 0).

This is related to zendframework/zend-mail#19 . While the error generates in Mail\Headers::fromString, it's caused by Mime\Decode::splitMessage parsing this case inconsistently.

I've added a test case using a stripped down version of the message in the referenced issue.
