### PR TITLE
Pin to stable deps known to be forwards-compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ matrix:
     - php: 7
     - php: hhvm 
   allow_failures:
-    - php: 7
     - php: hhvm
 
 notifications:

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
         }
     },
     "require": {
-        "php": ">=5.5",
-        "zendframework/zend-stdlib": "~2.5"
+        "php": "^5.5 || ^7.0",
+        "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
-        "zendframework/zend-mail": "~2.5",
+        "zendframework/zend-mail": "^2.6",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },


### PR DESCRIPTION
Following what was done in https://github.com/zendframework/zend-mail/pull/70 I propose the same changes.

The main advantage is the ability to use the new stdlib versions, since zend-mime is required in zend-mail, but zend-mime doesn't allow zend-stdlib 3.

I suppose this wil be a 2.6.\* tag.
