### PR TITLE
Fix error message when exception is created

### DIFF
--- a/src/Part.php
+++ b/src/Part.php
@@ -265,10 +265,10 @@ class Part
     public function setContent($content)
     {
         if (! is_string($content) && ! is_resource($content)) {
-            throw new Exception\InvalidArgumentException(
+            throw new Exception\InvalidArgumentException(sprintf(
                 "'%s' must be string or resource",
                 $content
-            );
+            ));
         }
         $this->content = $content;
         if (is_resource($content)) {


### PR DESCRIPTION
This fixes the following error message:

Fatal error: Wrong parameters for Exception([string $exception [, long $code [, Exception $previous = NULL]]]) /vendor/zendframework/zend-mime/src/Part.php on line 271
