### PR TITLE
Preventing creation of empty encode group =?<encoding>?Q??=

### DIFF
--- a/src/Mime.php
+++ b/src/Mime.php
@@ -212,11 +212,9 @@ class Mime
                 if ($noCurrentLine && $lineLimitReached) {
                     $lines[$currentLine] = $tmp;
                     $lines[$currentLine + 1] = '';
-                }
-                elseif ($lineLimitReached) {
+                } elseif ($lineLimitReached) {
                     $lines[$currentLine + 1] = $tmp;
-                }
-                else {
+                } else {
                     $lines[$currentLine] .= $tmp;
                 }
                 $tmp = '';

--- a/src/Mime.php
+++ b/src/Mime.php
@@ -207,9 +207,16 @@ class Mime
             if ($token === '=20') {
                 // only if we have a single char token or space, we can append the
                 // tempstring it to the current line or start a new line if necessary.
-                if (strlen($lines[$currentLine] . $tmp) > $lineLength) {
+                $lineLimitReached = (strlen($lines[$currentLine] . $tmp) > $lineLength);
+                $noCurrentLine = ($lines[$currentLine] === '');
+                if ($noCurrentLine && $lineLimitReached) {
+                    $lines[$currentLine] = $tmp;
+                    $lines[$currentLine + 1] = '';
+                }
+                elseif ($lineLimitReached) {
                     $lines[$currentLine + 1] = $tmp;
-                } else {
+                }
+                else {
                     $lines[$currentLine] .= $tmp;
                 }
                 $tmp = '';

--- a/test/MimeTest.php
+++ b/test/MimeTest.php
@@ -114,11 +114,12 @@ class MimeTest extends \PHPUnit_Framework_TestCase
             ["äöü", "UTF-8", "=?UTF-8?Q?=C3=A4=C3=B6=C3=BC?="],
             ["äöü ", "UTF-8", "=?UTF-8?Q?=C3=A4=C3=B6=C3=BC?="],
             ["Gimme more €", "UTF-8", "=?UTF-8?Q?Gimme=20more=20=E2=82=AC?="],
-            ["Alle meine Entchen schwimmen in dem See, schwimmen in dem See, Köpfchen in das Wasser, Schwänzchen in die Höh!", "UTF-8", "=?UTF-8?Q?Alle=20meine=20Entchen=20schwimmen=20in=20dem=20See,=20?=
- =?UTF-8?Q?schwimmen=20in=20dem=20See,=20K=C3=B6pfchen=20in=20das=20?=
- =?UTF-8?Q?Wasser,=20Schw=C3=A4nzchen=20in=20die=20H=C3=B6h!?="],
+            ["Alle meine Entchen schwimmen in dem See, schwimmen in dem See, Köpfchen in das Wasser, Schwänzchen in die Höh!", "UTF-8", "=?UTF-8?Q?Alle=20meine=20Entchen=20schwimmen=20in=20dem=20See,=20?=\n =?UTF-8?Q?schwimmen=20in=20dem=20See,=20K=C3=B6pfchen=20in=20das=20?=\n =?UTF-8?Q?Wasser,=20Schw=C3=A4nzchen=20in=20die=20H=C3=B6h!?="],
             ["ääääääääääääääääääääääääääääääääää", "UTF-8", "=?UTF-8?Q?=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4?="],
             ["A0", "UTF-8", "=?UTF-8?Q?A0?="],
+            ["äääääääääääääää ä", "UTF-8", "=?UTF-8?Q?=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=20?=\n =?UTF-8?Q?=C3=A4?="],
+            ["äääääääääääääää äääääääääääääää", "UTF-8", "=?UTF-8?Q?=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=20?=\n =?UTF-8?Q?=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4?="],
+            ["ä äääääääääääääää", "UTF-8", "=?UTF-8?Q?=C3=A4=20=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4=C3=A4?="],
         ];
     }
 


### PR DESCRIPTION
Found a wrong behaviour of non-ASCII header value encoding. It was creating empty encode group "=?UTF-8?Q??=" for "äääääääääääääää ä" in message subject. And some mail clients could not decode such "subject" properly.
Added minimal fix and few extra tests.
