### PR TITLE
Remove fast_finish flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ env:
     - secure: "KDeiKN5RyCXfmsQ49zOE61VNW8dr0EJXU4AKKstdAU5dhEmz62czPkuyAvWWGcDlGgkW3egR7lhNylYgZaUovi1DpbxaWEVBmApy/+g/JKLZH7QJM9r80XhRicSRp/kutuqCIOMBqEeSMw6HKOAlImvypwf1jXyVYlC9vahHKal6BQciA0deNqvNGgInyW/UihAL4U3stWM1d1ZbHhKAkBnXA6ttdsR60WlkvfEpW/yV2HVVl0pyauOHwNv2mWtovj6K+AL0F1KBPR6EozgfkEKvHxtrQWTzn6A0RqOVRmnLiQbzKsi1G0NBTDdKe2HRmGqJ1xyrP94cQ//IkOJoz26TiUqRdKAKFO/BEpoTbhY+9vepnsFkE54fLmstEkbP9Ebc3BnxguGgDrEVIDHVhO/eNgj2SbJNFZa6VHVaDbGWE4avRPQHRxxmSqqDq5wDjZgGWi+iqYy4ph5g1Fp5Y9v3S1HM9hmqiqMBvLnZf2To4w3uQxF/FjGnDdQ7L0lASUHXcrbsxw9zumeeaKdvL2uDdUsdmhuyWAKzpq4BDDkwOrfWK9SCk0Fh11yeRWbGiMvByccqczATVjbGCDly8Hg/jsdglmN+sZVCDWnuMOuFVzeUpQQ3mCzoyuZmPZhYwAEwA6lnQyHrt8/nkC7Mfooaik0i723SqROJWb0ibkg="
 
 matrix:
-  fast_finish: true
   include:
     - php: 5.5
       env:


### PR DESCRIPTION
It has been confirmed that the fast_finish flag is responsible for triggering multiple build notifications on #zftalk.dev.
