### PR TITLE
Allow parsing a non-multipart MIME message string into a Message

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -213,14 +213,21 @@ class Message
      * all the MIME parts set according to the given string
      *
      * @param string $message
-     * @param string $boundary
+     * @param string $boundary Multipart boundary; if omitted, $message will be
+     *                         treated as a single part
      * @param string $EOL EOL string; defaults to {@link Zend\Mime\Mime::LINEEND}
      * @throws Exception\RuntimeException
      * @return \Zend\Mime\Message
      */
-    public static function createFromMessage($message, $boundary, $EOL = Mime::LINEEND)
+    public static function createFromMessage($message, $boundary = null, $EOL = Mime::LINEEND)
     {
-        $parts = Decode::splitMessageStruct($message, $boundary, $EOL);
+        if ($boundary) {
+            $parts = Decode::splitMessageStruct($message, $boundary, $EOL);
+        } else {
+            Decode::splitMessage($message, $headers, $body, $EOL);
+            $parts = [['header' => $headers,
+                       'body'   => $body    ]];
+        }
 
         $res = new static();
         foreach ($parts as $part) {

--- a/test/MessageTest.php
+++ b/test/MessageTest.php
@@ -147,6 +147,27 @@ EOD;
         $this->assertEquals('image/gif', $part2->type);
     }
 
+    /**
+     * Check if decoding a string that is not a multipart message works
+     */
+    public function testDecodeNonMultipartMimeMessage()
+    {
+        $text = <<<EOD
+Content-Type: image/gif
+
+This is a test
+EOD;
+        $res = Mime\Message::createFromMessage($text);
+
+        $parts = $res->getParts();
+        $this->assertEquals(1, count($parts));
+
+        $part1 = $parts[0];
+        $part1Content = $part1->getRawContent();
+        $this->assertEquals('This is a test', $part1Content);
+        $this->assertEquals('image/gif', $part1->type);
+    }
+
     public function testNonMultipartMessageShouldNotRemovePartFromMessage()
     {
         $message = new Mime\Message();  // No Parts


### PR DESCRIPTION
Currently, `Message::createFromMessage( $message, $boundary [, $EOL] )` only works for multipart messages.

This PR allows omitting the `$boundary` parameter, in which case `$message` will be interpreted as the sole part of the message.

One place where this would be helpful parsing the body of non-multipart e-mail messages. That would allow consistent handling of said body as a `Message` object.