### PR TITLE
Zend\Mime\Message setter methods should return $this

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -28,10 +28,12 @@ class Message
      * Sets the given array of Zend\Mime\Part as the array for the message
      *
      * @param array $parts
+     * @return self
      */
     public function setParts($parts)
     {
         $this->parts = $parts;
+        return $this;
     }
 
     /**
@@ -39,6 +41,7 @@ class Message
      *
      * @param \Zend\Mime\Part $part
      * @throws Exception\InvalidArgumentException
+     * @return self
      */
     public function addPart(Part $part)
     {
@@ -52,6 +55,7 @@ class Message
         }
 
         $this->parts[] = $part;
+        return $this;
     }
 
     /**
@@ -72,10 +76,12 @@ class Message
      * Zend\Mime for generating the boundary.
      *
      * @param \Zend\Mime\Mime $mime
+     * @return self
      */
     public function setMime(Mime $mime)
     {
         $this->mime = $mime;
+        return $this;
     }
 
     /**


### PR DESCRIPTION
All of the setter methods in `Zend\Mime\Part` and `Zend\Mail\Message` return `$this`, allowing you to chain calls to those methods. `Zend\Mime\Message` doesn't work this way, for seemingly no particular reason.

The PR simply adds `return $this` to those few setter functions. There should be no API breakage or other BC issues AFAIK. Tests pass (there weren't any that relied on the existing behaviour, of course).