### PR TITLE
Fix message parsing with CRLF

### DIFF
--- a/src/Decode.php
+++ b/src/Decode.php
@@ -122,16 +122,23 @@ class Decode
             }
         }
 
+        // TODO: splitMime replaces removes \r which breaks
+        //       valid mime messages as returned by many mail servers
+        $headersEOL = $EOL;
+
         // find an empty line between headers and body
         // default is set new line
+        // TODO: Maybe this is too much "magic", we should be more strict here
         if (strpos($message, $EOL . $EOL)) {
             list($headers, $body) = explode($EOL . $EOL, $message, 2);
         // next is the standard new line
         } elseif ($EOL != "\r\n" && strpos($message, "\r\n\r\n")) {
             list($headers, $body) = explode("\r\n\r\n", $message, 2);
+            $headersEOL = "\r\n"; // Headers::fromString will fail with incorrect eol
         // next is the other "standard" new line
         } elseif ($EOL != "\n" && strpos($message, "\n\n")) {
             list($headers, $body) = explode("\n\n", $message, 2);
+            $headersEOL = "\n";
         // at last resort find anything that looks like a new line
         } else {
             ErrorHandler::start(E_NOTICE | E_WARNING);
@@ -139,7 +146,7 @@ class Decode
             ErrorHandler::stop();
         }
 
-        $headers = Headers::fromString($headers, $EOL);
+        $headers = Headers::fromString($headers, $headersEOL);
     }
 
     /**

--- a/test/MessageTest.php
+++ b/test/MessageTest.php
@@ -10,6 +10,7 @@
 namespace ZendTest\Mime;
 
 use Zend\Mime;
+use Zend\Mime\Message;
 
 /**
  * @group      Zend_Mime
@@ -199,5 +200,26 @@ EOD;
         $part    = new Mime\Part('This is a test');
         $message->addPart($part);
         $message->addPart($part);
+    }
+
+    public function testFromStringWithCrlfAndRfc2822FoldedHeaders()
+    {
+        // This is a fixture as provided by many mailservers
+        // e.g. cyrus or dovecot
+        $eol = "\r\n";
+        $fixture = 'This is a MIME-encapsulated message' . $eol . $eol
+                 . '--=_af4357ef34b786aae1491b0a2d14399f' . $eol
+                 . 'Content-Type: text/plain' . $eol
+                 . 'Content-Disposition: attachment;' . $eol
+                 . "\t" . 'filename="test.txt"' . $eol // Valid folding
+                 . $eol
+                 . 'This is a test' . $eol
+                 . '--=_af4357ef34b786aae1491b0a2d14399f--';
+
+        $message = Message::createFromMessage($fixture, '=_af4357ef34b786aae1491b0a2d14399f', $eol);
+        $parts = $message->getParts();
+
+        $this->assertEquals(1, count($parts));
+        $this->assertEquals('attachment; filename="test.txt"', $parts[0]->getDisposition());
     }
 }


### PR DESCRIPTION
Many Mailservers and Useragents use CRLF as EOL for Mime messages.
`Decode::splitMime()` removes `\r` which breaks `Headers::fromString()` with `$EOL` set to `\r\n` especially when they contain RFC2822 header folding.

This pull request adds a testcase for this scenario and implements a hotfix.
