### PR TITLE
fix infinite loop

### DIFF
--- a/src/Mime.php
+++ b/src/Mime.php
@@ -125,21 +125,28 @@ class Mime
                 $ptr = $lineLength;
             }
 
-            // Try to prevent that the first character of a line is a dot
-            // Outlook Bug: http://engineering.como.com/ghost-vs-outlook/
-            while ($ptr > 1 && $ptr < strlen($str) && $str[$ptr] === '.') {
-                --$ptr;
-            }
-
             // Ensure we are not splitting across an encoded character
             $pos = strrpos(substr($str, 0, $ptr), '=');
             if ($pos !== false && $pos >= $ptr - 2) {
                 $ptr = $pos;
             }
 
-            // Check if there is a space at the end of the line and rewind
-            if ($ptr > 0 && $str[$ptr - 1] == ' ') {
-                --$ptr;
+            switch (ord($str[0])) {
+                case 0x2E:
+                    $str  = '=2E' . substr($str, 1);
+                    $ptr += 2;
+                    break;
+            }
+
+            switch (ord(substr($str, $ptr - 1))) {
+                case 0x09:
+                    $str  = substr_replace($str, '=09', $ptr - 1, 1);
+                    $ptr += 2;
+                    break;
+                case 0x20:
+                    $str  = substr_replace($str, '=20', $ptr - 1, 1);
+                    $ptr += 2;
+                    break;
             }
 
             // Add string and continue

--- a/src/Mime.php
+++ b/src/Mime.php
@@ -131,7 +131,7 @@ class Mime
                 $ptr = $pos;
             }
 
-            if (ord($str[0]) == 0x2E) {
+            if (ord($str[0]) == 0x2E) { // 0x2E is a dot
                 $str  = '=2E' . substr($str, 1);
                 $ptr += 2;
             }

--- a/src/Mime.php
+++ b/src/Mime.php
@@ -131,19 +131,18 @@ class Mime
                 $ptr = $pos;
             }
 
-            switch (ord($str[0])) {
-                case 0x2E:
-                    $str  = '=2E' . substr($str, 1);
-                    $ptr += 2;
-                    break;
+            if (ord($str[0]) == 0x2E) {
+                $str  = '=2E' . substr($str, 1);
+                $ptr += 2;
             }
 
+            // copied from swiftmailer https://git.io/vAXU1
             switch (ord(substr($str, $ptr - 1))) {
-                case 0x09:
+                case 0x09: // Horizontal Tab
                     $str  = substr_replace($str, '=09', $ptr - 1, 1);
                     $ptr += 2;
                     break;
-                case 0x20:
+                case 0x20: // Space
                     $str  = substr_replace($str, '=20', $ptr - 1, 1);
                     $ptr += 2;
                     break;

--- a/test/MimeTest.php
+++ b/test/MimeTest.php
@@ -87,7 +87,7 @@ class MimeTest extends TestCase
         $text = str_repeat('a', Mime\Mime::LINELENGTH) . '.bbb';
         $qp = Mime\Mime::encodeQuotedPrintable($text);
 
-        $expected = str_repeat('a', Mime\Mime::LINELENGTH - 1) . "=\na.bbb";
+        $expected = str_repeat('a', Mime\Mime::LINELENGTH) . "=\n=2Ebbb";
 
         $this->assertEquals($expected, $qp);
     }
@@ -97,17 +97,17 @@ class MimeTest extends TestCase
         $text = str_repeat(' ', Mime\Mime::LINELENGTH) . str_repeat('.', Mime\Mime::LINELENGTH);
         $qp = Mime\Mime::encodeQuotedPrintable($text);
 
-        $expected = str_repeat(' ', Mime\Mime::LINELENGTH - 2) . "=\n  " . str_repeat('.', Mime\Mime::LINELENGTH - 2) . "=\n..";
+        $expected = str_repeat(' ', Mime\Mime::LINELENGTH - 1) . "=20=\n=2E" . str_repeat('.', Mime\Mime::LINELENGTH - 1);
 
         $this->assertEquals($expected, $qp);
     }
 
     public function testQuotedPrintableDoesNotBreakOctets()
     {
-        $text = str_repeat('a', Mime\Mime::LINELENGTH - 3) . '=.bbb';
+        $text = str_repeat('a', Mime\Mime::LINELENGTH - 2) . '=.bbb';
         $qp = Mime\Mime::encodeQuotedPrintable($text);
 
-        $expected = str_repeat('a', Mime\Mime::LINELENGTH - 3) . "=\n=3D.bbb";
+        $expected = str_repeat('a', Mime\Mime::LINELENGTH - 2) . "=\n=3D.bbb";
 
         $this->assertEquals($expected, $qp);
     }

--- a/test/MimeTest.php
+++ b/test/MimeTest.php
@@ -92,6 +92,16 @@ class MimeTest extends TestCase
         $this->assertEquals($expected, $qp);
     }
 
+    public function testQuotedPrintableSpacesAndDots()
+    {
+        $text = str_repeat(' ', Mime\Mime::LINELENGTH) . str_repeat('.', Mime\Mime::LINELENGTH);
+        $qp = Mime\Mime::encodeQuotedPrintable($text);
+
+        $expected = str_repeat(' ', Mime\Mime::LINELENGTH - 2) . "=\n  " . str_repeat('.', Mime\Mime::LINELENGTH - 2) . "=\n..";
+
+        $this->assertEquals($expected, $qp);
+    }
+
     public function testQuotedPrintableDoesNotBreakOctets()
     {
         $text = str_repeat('a', Mime\Mime::LINELENGTH - 3) . '=.bbb';


### PR DESCRIPTION
If a message contains 72 spaces and 72 dots at one line we have an infinite loop. This pull request fix this behavior.
I'll replace the last space at one line always with =20. I'll also replace the first dot at one line always with =2E.
Swiftmail do it the same way and it works fine.