### PR TITLE
Fix header type inconsistency

### DIFF
--- a/src/Decode.php
+++ b/src/Decode.php
@@ -108,7 +108,7 @@ class Decode
         $firstlinePos = strpos($message, "\n");
         $firstline = $firstlinePos === false ? $message : substr($message, 0, $firstlinePos);
         if (! preg_match('%^[^\s]+[^:]*:%', $firstline)) {
-            $headers = [];
+            $headers = new Headers();
             // TODO: we're ignoring \r for now - is this function fast enough and is it safe to assume noone needs \r?
             $body = str_replace(["\r", "\n"], ['', $EOL], $message);
             return;


### PR DESCRIPTION
There is a small inconsistency the way `Decode:: splitMessage()` behaves, the `headers` variable referenced in splitMessage is supposed to of type `Headers` always, but when splitMessage is called with an empty content `headers` will become an empty array. This breaks client libraries for example: https://github.com/zendframework/zend-mail/blob/master/src/Message.php#L566 

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.
