### PR TITLE
Fix env var in Travis CI configuration - CS_CHECK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
     - php: 7
       env:
         - DEPS=locked
-        - CHECK_CS=true
+        - CS_CHECK=true
         - TEST_COVERAGE=true
     - php: 7
       env:


### PR DESCRIPTION
CS check was not running with Travis CI builds due to invalid env var name.

- [x] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->

