### PR TITLE
Lowercase composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "zendframework/zend-mail": "^2.6",
-        "phpunit/PHPUnit": "^5.7.21 || ^6.3",
+        "phpunit/phpunit": "^5.7.21 || ^6.3",
         "zendframework/zend-coding-standard": "~1.0.0"
     },
     "suggest": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9238ebcc59bf0b5995894d83e3663451",
+    "content-hash": "fe3621b89823f4acc6a677ac231063e0",
     "packages": [
         {
             "name": "zendframework/zend-stdlib",


### PR DESCRIPTION
Uppercase characters in package name are deprecated and will error in Composer 2.0

- [x] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->
